### PR TITLE
Battery should use ceiling value

### DIFF
--- a/watch_faces/BinarySystem/source/DataViews/BatteryView.mc
+++ b/watch_faces/BinarySystem/source/DataViews/BatteryView.mc
@@ -162,8 +162,10 @@ function draw(dc)
         var battery = sysStats.battery;
             //===============================
             //!battery percentage
-            //===============================
-            var batteryPercentageStr = Math.ceil(battery).format("%d");
+            //===============================           
+            var batteryPercentageStr = Math.round(battery).format("%d");
+            //Sys.println("string: "+  batteryPercentageString);
+            
             //batteryPrediction(seconds, battery, 24);
 
             if (remainingBatteryEstimateMode) {

--- a/watch_faces/BinarySystem/source/DataViews/BatteryView.mc
+++ b/watch_faces/BinarySystem/source/DataViews/BatteryView.mc
@@ -163,7 +163,7 @@ function draw(dc)
             //===============================
             //!battery percentage
             //===============================
-            var batteryPercentageStr = battery.format("%d");
+            var batteryPercentageStr = Math.ceil(battery).format("%d");
             //batteryPrediction(seconds, battery, 24);
 
             if (remainingBatteryEstimateMode) {


### PR DESCRIPTION
This shows the ceiling value for the battery, and thus reflects much better how much battery is actually left (consistent with the Garmin value)